### PR TITLE
Add API route tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,8 @@
         "pg": "^8.16.3"
       },
       "devDependencies": {
-        "jest": "^29.7.0"
+        "jest": "^29.7.0",
+        "supertest": "^6.3.3"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1258,6 +1259,29 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
+      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
+      }
+    },
     "node_modules/@sinclair/typebox": {
       "version": "0.27.8",
       "resolved": "https://registry.npmjs.org/@sinclair/typebox/-/typebox-0.27.8.tgz",
@@ -1460,6 +1484,20 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/babel-jest": {
       "version": "29.7.0",
@@ -1922,6 +1960,29 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -1967,6 +2028,13 @@
       "engines": {
         "node": ">=6.6.0"
       }
+    },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/cors": {
       "version": "2.8.5",
@@ -2106,6 +2174,16 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -2123,6 +2201,17 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/diff-sequences": {
@@ -2226,6 +2315,22 @@
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
       },
       "engines": {
         "node": ">= 0.4"
@@ -2369,6 +2474,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fb-watchman": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/fb-watchman/-/fb-watchman-2.0.2.tgz",
@@ -2421,6 +2533,62 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
+      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
+      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0",
+        "qs": "^6.11.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -2608,6 +2776,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -4382,6 +4566,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/micromatch": {
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
@@ -4394,6 +4588,19 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -5390,6 +5597,56 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "8.1.2",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
+      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
+      "deprecated": "Please upgrade to v9.0.0+ as we have fixed a public vulnerability with formidable dependency. Note that v9.0.0+ requires Node.js v14.18.0+. See https://github.com/ladjs/superagent/pull/1800 for insight. This project is supported and maintained by the team at Forward Email @ https://forwardemail.net",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.0",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.4",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.0",
+        "formidable": "^2.1.2",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.11.0",
+        "semver": "^7.3.8"
+      },
+      "engines": {
+        "node": ">=6.4.0 <13 || >=14"
+      }
+    },
+    "node_modules/superagent/node_modules/semver": {
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "6.3.4",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-6.3.4.tgz",
+      "integrity": "sha512-erY3HFDG0dPnhw4U+udPfrzXa4xhSG+n4rxfRuZWCUvjFWwKl+OxWf/7zk50s84/fAAs7vf5QAb9uRa0cCykxw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "methods": "^1.1.2",
+        "superagent": "^8.1.2"
+      },
+      "engines": {
+        "node": ">=6.4.0"
       }
     },
     "node_modules/supports-preserve-symlinks-flag": {

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
   "license": "ISC",
   "type": "commonjs",
   "devDependencies": {
-    "jest": "^29.7.0"
+    "jest": "^29.7.0",
+    "supertest": "^6.3.3"
   },
   "dependencies": {
     "cors": "^2.8.5",

--- a/server/api.test.js
+++ b/server/api.test.js
@@ -1,0 +1,76 @@
+const request = require('supertest');
+const fs = require('fs');
+const path = require('path');
+const { createApp } = require('./app');
+const { summarizeText } = require('./utils');
+
+class FakePool {
+  constructor() {
+    this.posts = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'sample-data.json'), 'utf-8')
+    );
+  }
+
+  async query(sql, params) {
+    if (sql.startsWith('SELECT id, title, author, created_at FROM posts')) {
+      return {
+        rows: this.posts.map(({ id, title, author, created_at }) => ({
+          id,
+          title,
+          author,
+          created_at,
+        })),
+      };
+    }
+
+    if (sql.startsWith('SELECT * FROM posts WHERE id=$1')) {
+      const post = this.posts.find((p) => p.id === Number(params[0]));
+      return { rows: post ? [post] : [] };
+    }
+
+    if (sql.startsWith('SELECT content FROM posts WHERE id=$1')) {
+      const post = this.posts.find((p) => p.id === Number(params[0]));
+      return { rows: post ? [{ content: post.content }] : [] };
+    }
+
+    throw new Error('Unexpected query: ' + sql);
+  }
+}
+
+describe('API routes', () => {
+  let app;
+  let data;
+
+  beforeAll(() => {
+    data = JSON.parse(
+      fs.readFileSync(path.join(__dirname, '..', 'sample-data.json'), 'utf-8')
+    );
+    app = createApp(new FakePool());
+  });
+
+  test('GET /api/posts returns basic info', async () => {
+    const res = await request(app).get('/api/posts');
+    expect(res.status).toBe(200);
+    const expected = data.map((p) => ({
+      id: p.id,
+      title: p.title,
+      author: p.author,
+      created_at: p.created_at,
+    }));
+    expect(res.body).toEqual(expected);
+  });
+
+  test('GET /api/posts/:id returns full post', async () => {
+    const post = data[0];
+    const res = await request(app).get(`/api/posts/${post.id}`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(post);
+  });
+
+  test('POST /api/posts/:id/summarize returns summary', async () => {
+    const post = data[0];
+    const res = await request(app).post(`/api/posts/${post.id}/summarize`);
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ summary: summarizeText(post.content) });
+  });
+});

--- a/server/app.js
+++ b/server/app.js
@@ -1,0 +1,39 @@
+const express = require('express');
+const cors = require('cors');
+const { summarizeText } = require('./utils');
+
+function createApp(pool) {
+  const app = express();
+  app.use(cors());
+  app.use(express.json());
+
+  app.get('/api/posts', async (req, res) => {
+    const result = await pool.query('SELECT id, title, author, created_at FROM posts ORDER BY id');
+    res.json(result.rows);
+  });
+
+  app.get('/api/posts/:id', async (req, res) => {
+    const id = req.params.id;
+    const result = await pool.query('SELECT * FROM posts WHERE id=$1', [id]);
+    if (result.rows.length === 0) return res.status(404).send('Not found');
+    res.json(result.rows[0]);
+  });
+
+  app.post('/api/posts/:id/summarize', async (req, res) => {
+    const id = req.params.id;
+    const result = await pool.query('SELECT content FROM posts WHERE id=$1', [id]);
+    if (result.rows.length === 0) return res.status(404).send('Not found');
+
+    const content = result.rows[0].content;
+    try {
+      const summary = summarizeText(content);
+      res.json({ summary });
+    } catch (e) {
+      res.status(500).json({ error: 'Summarization failed' });
+    }
+  });
+
+  return app;
+}
+
+module.exports = { createApp };

--- a/server/index.js
+++ b/server/index.js
@@ -1,20 +1,14 @@
-const express = require('express');
-const cors = require('cors');
 const { Pool } = require('pg');
-const { summarizeText } = require('./utils');
 const fs = require('fs');
 const path = require('path');
+const { createApp } = require('./app');
 
-const app = express();
-app.use(cors());
-app.use(express.json());
+const connectionString =
+  process.env.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/ai_blog';
+const pool = new Pool({ connectionString });
 
-const pool = new Pool({
-  connectionString: process.env.DATABASE_URL || 'postgresql://postgres:postgres@localhost:5432/ai_blog'
-});
-
-async function init() {
-  await pool.query(`CREATE TABLE IF NOT EXISTS posts (
+async function init(poolInstance) {
+  await poolInstance.query(`CREATE TABLE IF NOT EXISTS posts (
     id INTEGER PRIMARY KEY,
     title TEXT,
     author TEXT,
@@ -22,12 +16,12 @@ async function init() {
     content TEXT
   )`);
 
-  const count = await pool.query('SELECT COUNT(*) FROM posts');
+  const count = await poolInstance.query('SELECT COUNT(*) FROM posts');
   if (parseInt(count.rows[0].count) === 0) {
     const dataPath = path.join(__dirname, '..', 'sample-data.json');
     const posts = JSON.parse(fs.readFileSync(dataPath, 'utf-8'));
     for (const p of posts) {
-      await pool.query(
+      await poolInstance.query(
         'INSERT INTO posts(id, title, author, created_at, content) VALUES($1,$2,$3,$4,$5)',
         [p.id, p.title, p.author, p.created_at, p.content]
       );
@@ -35,33 +29,12 @@ async function init() {
   }
 }
 
-app.get('/api/posts', async (req, res) => {
-  const result = await pool.query('SELECT id, title, author, created_at FROM posts ORDER BY id');
-  res.json(result.rows);
-});
+if (require.main === module) {
+  const app = createApp(pool);
+  const PORT = process.env.PORT || 3001;
+  init(pool).then(() => {
+    app.listen(PORT, () => console.log('Server running on', PORT));
+  });
+}
 
-app.get('/api/posts/:id', async (req, res) => {
-  const id = req.params.id;
-  const result = await pool.query('SELECT * FROM posts WHERE id=$1', [id]);
-  if (result.rows.length === 0) return res.status(404).send('Not found');
-  res.json(result.rows[0]);
-});
-
-app.post('/api/posts/:id/summarize', async (req, res) => {
-  const id = req.params.id;
-  const result = await pool.query('SELECT content FROM posts WHERE id=$1', [id]);
-  if (result.rows.length === 0) return res.status(404).send('Not found');
-
-  const content = result.rows[0].content;
-  try {
-    const summary = summarizeText(content);
-    res.json({ summary });
-  } catch (e) {
-    res.status(500).json({ error: 'Summarization failed' });
-  }
-});
-
-const PORT = process.env.PORT || 3001;
-init().then(() => {
-  app.listen(PORT, () => console.log('Server running on', PORT));
-});
+module.exports = { createApp, init, pool };


### PR DESCRIPTION
## Summary
- export Express app and initialization helpers
- add app wrapper file with blog routes
- add API tests for blog endpoints
- include supertest as a dev dependency

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6862b9c8ae948323a03c0179b72eda4b